### PR TITLE
Task 3: Get data from /products api endpoint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,4 @@ node_modules
 public
 vite.config.ts
 serverless.yml
+*.local

--- a/src/constants/apiPaths.ts
+++ b/src/constants/apiPaths.ts
@@ -1,8 +1,10 @@
+const apiGateway = import.meta.env.VITE_API_GATEWAY_ID;
+
 const API_PATHS = {
   product: "https://.execute-api.eu-west-1.amazonaws.com/dev",
   order: "https://.execute-api.eu-west-1.amazonaws.com/dev",
   import: "https://.execute-api.eu-west-1.amazonaws.com/dev",
-  bff: "https://.execute-api.eu-west-1.amazonaws.com/dev",
+  bff: `https://${apiGateway}.execute-api.eu-west-1.amazonaws.com/`,
   cart: "https://.execute-api.eu-west-1.amazonaws.com/dev",
 };
 

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -5,6 +5,7 @@ import { CartItem } from "~/models/CartItem";
 import { Order } from "~/models/Order";
 import { AvailableProduct, Product } from "~/models/Product";
 
+// TODO: remove unused handlers
 export const handlers = [
   rest.get(`${API_PATHS.bff}/product`, (req, res, ctx) => {
     return res(ctx.status(200), ctx.delay(), ctx.json<Product[]>(products));

--- a/src/queries/products.ts
+++ b/src/queries/products.ts
@@ -9,7 +9,7 @@ export function useAvailableProducts() {
     "available-products",
     async () => {
       const res = await axios.get<AvailableProduct[]>(
-        `${API_PATHS.bff}/product/available`
+        `${API_PATHS.bff}/products`
       );
       return res.data;
     }

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,2 +1,10 @@
 /// <reference types="vitest" />
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+    readonly VITE_API_GATEWAY_ID: string
+  }
+  
+  interface ImportMeta {
+    readonly env: ImportMetaEnv
+  }


### PR DESCRIPTION
Integration of new `/products` API endpoint, which triggers `getProductsList` lambda function behind the scenes, returning mocked list of products to display.